### PR TITLE
feat: パスワード生成処理の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.vscode/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+pub fn build_char_pool(uppercase: bool, digits:bool, symbols: bool) -> String {
+    let mut char_pool = String::from("abcdefghijklmnopqrstuvwxyz");
+
+    if uppercase {
+        char_pool.push_str("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    }
+
+    if digits {
+        char_pool.push_str("0123456789");
+    }
+
+    if symbols {
+        char_pool.push_str("!@#$%&&'()=~");
+    }
+    char_pool
+}
+
+pub fn generate_password(length: usize, char_pool: &str) -> String {
+    let mut rng = thread_rng();
+    let pool_chars: Vec<char> = char_pool.chars().collect();
+
+    (0..length)
+        .map(|_| {
+            *pool_chars.choose(&mut rng).expect("Failed to generate password")
+        })
+        .collect::<String>()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,62 @@ pub fn generate_password(length: usize, char_pool: &str) -> String {
         })
         .collect::<String>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_char_pool_default() {
+        assert_eq!(
+            build_char_pool(false, false, false),
+            "abcdefghijklmnopqrstuvwxyz"
+        );
+    }
+
+    #[test]
+    fn test_build_char_pool_with_uppercase() {
+        assert_eq!(
+            build_char_pool(true, false, false),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        );
+    }
+
+    #[test]
+    fn test_build_char_pool_with_digits() {
+        assert_eq!(
+            build_char_pool(false, true, false),
+            "abcdefghijklmnopqrstuvwxyz0123456789"
+        );
+    }
+
+    #[test]
+    fn test_build_char_pool_with_symbols() {
+        assert_eq!(
+            build_char_pool(false, false, true),
+            "abcdefghijklmnopqrstuvwxyz!@#$%&&'()=~"
+        );
+    }
+
+    #[test]
+    fn test_build_char_pool_all_option() {
+        assert_eq!(
+            build_char_pool(true, true, true),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%&&'()=~"
+        );
+    }
+
+    #[test]
+    fn test_generate_password_length() {
+        let char_pool = build_char_pool(false, false, false);
+        let password = generate_password(16, &char_pool);
+        assert_eq!(password.len(), 16);
+    }
+
+    #[test]
+    fn test_generate_password_char_pool() {
+        let char_pool = build_char_pool(false, false, false);
+        let password = generate_password(16, &char_pool);
+        assert_eq!(password.chars().all(|c| char_pool.contains(c)), true);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ struct Args {
 
     // 生成パスワードに数値を含めるか
     #[arg(short, long, default_value = "false")]
-    digit: bool,
+    digits: bool,
 
     // 大文字あり/なし
     #[arg(short, long, default_value = "false")]
@@ -26,24 +26,15 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
+
+    let char_pool = pwgen::build_char_pool(
+        args.uppercase, 
+        args.digits, 
+        args.symbols
+    );
     
     for _ in 0..args.count {
-        println!("指定されたパスワードの長さは {}", args.length);
-
-        // オプション受け取りテスト
-        // 大文字指定があったら
-        if args.uppercase {
-            println!("大文字あり");
-        }
-
-        // 記号指定があったら
-        if args.symbols {
-            println!("記号あり");
-        }
-
-        // 数値指定があったら
-        if args.digit {
-            println!("数値あり");
-        }
+        let password = pwgen::generate_password(args.length as usize, &char_pool);
+        println!("{}",password);
     }
 }


### PR DESCRIPTION
## 概要

パスワード生成処理の実装
CLIで生成処理の呼び出し

## 細かく説明

* lib.rs を生成してメインロジックの定義 + unit テストの実装
* .gitignore にVSCode依存のファイルを追加
* main.rs
  * digits にオプション引数の命名を修正
  * メイン処理でパスワード生成処理の呼び出し